### PR TITLE
[Feat] 기본 애니메이션 캐릭터 구현 및 이미지 업로드 시 데이터베이스 저장

### DIFF
--- a/app/src/main/java/com/hideinbash/tododudu/CharacterEditDialog.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/CharacterEditDialog.kt
@@ -1,0 +1,125 @@
+package com.hideinbash.tododudu
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import com.bumptech.glide.Glide
+import com.hideinbash.tododudu.databinding.CharacterEditDialogBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+
+class CharacterEditDialog(
+    private val uri: Uri?,
+    private var body : MultipartBody.Part?,
+    private val onComplete: (() -> Unit)? = null
+) : DialogFragment() {
+    lateinit var binding: CharacterEditDialogBinding
+    var url : String? = null
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = CharacterEditDialogBinding.inflate(inflater, container, false)
+
+
+
+        if(uri != null){
+            binding.defaultCharacterIv.setImageURI(uri)
+        }
+        binding.btnCharConversionBtn.setOnClickListener {
+            uploadImageToFlask()
+        }
+        binding.btnCharSaveBtn.setOnClickListener {
+            saveAtPref()
+        }
+
+        return binding.root
+    }
+
+    fun saveAtPref(){
+        if(url == null){
+            Toast.makeText(requireContext(), "애니메이션이 전환되지 않았습니다", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val prefs = requireContext().getSharedPreferences("user_info_data", 0)
+        prefs.edit().putString("character",url).apply()
+        onComplete?.invoke()
+        dismiss()
+    }
+
+    fun uploadImageToFlask() {
+        CoroutineScope(Dispatchers.Main).launch {
+            val loadingDialog = LoadingDialog(requireContext()) // 로딩창 생성
+            loadingDialog.show()
+
+            if (body == null) {
+                loadingDialog.dismiss()
+                Toast.makeText(requireContext(), "사진이 받아와지지 않았습니다", Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+
+            val client = OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build()
+
+            val requestBody = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addPart(body!!)
+                .build()
+
+            val request = Request.Builder()
+                .url("http://13.55.149.37:5000/gif/inside")
+                .post(requestBody)
+                .build()
+
+            try {
+                // 백그라운드 처리
+                val response = withContext(Dispatchers.IO) {
+                    client.newCall(request).execute()
+                }
+
+                val responseBody = response.body?.string()
+                if (responseBody != null) {
+                    val gifUrl = JSONObject(responseBody).getString("gif_url")
+                    Log.d("gif-test", "응답 성공, $gifUrl")
+                    url = gifUrl
+                    Glide.with(requireContext())
+                        .load(gifUrl)
+                        .into(binding.defaultCharacterIv)
+                } else {
+                    Log.d("gif-test", "응답 본문이 null입니다.")
+                }
+
+            } catch (e: Exception) {
+                Log.e("gif-test", "에러 발생: ${e.message}")
+            } finally {
+                loadingDialog.dismiss() // 무조건 로딩창 닫기
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(
+            (resources.displayMetrics.widthPixels * 0.9).toInt(), // 화면의 90% 너비
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+}

--- a/app/src/main/java/com/hideinbash/tododudu/CharacterEditDialog.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/CharacterEditDialog.kt
@@ -47,6 +47,9 @@ class CharacterEditDialog(
         binding.btnCharSaveBtn.setOnClickListener {
             saveAtPref()
         }
+        binding.editDialogCloseBtn.setOnClickListener {
+            dismiss()
+        }
 
         return binding.root
     }

--- a/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
@@ -1,11 +1,13 @@
 package com.hideinbash.tododudu
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.bumptech.glide.Glide
 import com.hideinbash.tododudu.databinding.FragmentHomeBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +36,7 @@ class HomeFragment:Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         loadAllData()
-
+        Log.d("onViewCheck", "check")
         monsterAdapter = MonsterAdapter(
             items = emptyList(),
             onItemClick = { todo ->
@@ -55,11 +57,17 @@ class HomeFragment:Fragment() {
 
     private fun loadAllData() {
         CoroutineScope(Dispatchers.IO).launch {
+
+
             // 1. XP & 레벨 데이터 (SharedPreferences)
             val prefs = requireContext().getSharedPreferences("user_data", 0)
             val xp = prefs.getInt("xp", 0)
             val level = prefs.getInt("level", 1)
             val xpForNext = 100 + (level - 1) * 20
+
+            // 1-1. 마이페이지의 닉네임과 캐릭터 정보
+            val info_prefs = requireContext().getSharedPreferences("user_info_data", 0)
+            val character = info_prefs.getString("character","https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif")
 
             // 2. 할 일 데이터 (RoomDB)
             val db = TodoDatabase.getInstance(requireContext())
@@ -81,6 +89,11 @@ class HomeFragment:Fragment() {
 
                 // 몬스터 리스트
                 monsterAdapter.updateList(yetTodos)
+
+                //메인 캐릭터 이미지
+                Glide.with(requireContext())
+                    .load(character) // S3 이미지 URL
+                    .into(binding.homeMainCharacterIv)
             }
         }
     }

--- a/app/src/main/res/layout/character_edit_dialog.xml
+++ b/app/src/main/res/layout/character_edit_dialog.xml
@@ -45,5 +45,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/btn_char_conversion_btn"
         android:background="@drawable/mypage_mainbtn_bg"/>
-
+    <!-- 닫기(X) 버튼 -->
+    <ImageView
+        android:id="@+id/edit_dialog_close_btn"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:src="@drawable/baseline_close_24"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/character_edit_dialog.xml
+++ b/app/src/main/res/layout/character_edit_dialog.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@drawable/mypage_wood_bg"
+    android:padding="24dp">
+
+    <ImageView
+        android:id="@+id/default_character_iv"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:src="@drawable/mypage_default_char"
+        />
+    <TextView
+        android:id="@+id/btn_char_conversion_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="사진 전환"
+        android:textSize="28dp"
+        android:fontFamily="@font/dos_gothic"
+        android:gravity="center"
+        android:textStyle="bold"
+        android:textColor="@color/white"
+        android:layout_marginTop="30dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/default_character_iv"
+        android:background="@drawable/mypage_mainbtn_bg"/>
+    <TextView
+        android:id="@+id/btn_char_save_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="캐릭터 저장"
+        android:textSize="28dp"
+        android:fontFamily="@font/dos_gothic"
+        android:gravity="center"
+        android:textStyle="bold"
+        android:textColor="@color/white"
+        android:layout_marginTop="30dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_char_conversion_btn"
+        android:background="@drawable/mypage_mainbtn_bg"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -89,7 +89,7 @@
         android:layout_marginStart="35dp"
 
         />
-    <TextView
+    <EditText
         android:id="@+id/nickname_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -102,8 +102,12 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="80dp"
+        android:layout_marginTop="70dp"
         android:foregroundGravity="center"
+        android:inputType="text"
+        android:imeOptions="actionDone"
+        android:enabled="false"
+        android:focusable="false"
         />
     <TextView
         android:id="@+id/btn_nickname_chg"
@@ -119,7 +123,8 @@
         app:layout_constraintTop_toTopOf="parent"
         android:layout_marginTop="80dp"
         android:layout_marginEnd="35dp"
-        android:background="@drawable/mypage__chg_btn_bg"/>
+        android:background="@drawable/mypage__chg_btn_bg"
+        />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
1. 마이페이지에서 갤러리에서 업로드할때 사진 업로드 눌러서 가져오고 업로드 버튼을 하나 더 만들어서 서버에 업로드하기 (업로드된 s3 링크를 sharedpreference로 저장해서 로딩해놓으면 될듯)
=>다이얼로그를 새로 만들어서 그 안에서 이미지 업로드 및 저장 버튼 제작하였음

2. 기본 이미지는 누르면 기본 양파 or 기본 캐릭터 하나 새로 괜찮은거 만들어서 그거 로딩되게 하기 (피그마대로)
=>기본 캐릭터로써 하나 넣음

3. 마이페이지에서 닉네임 수정 구현하기 (sharedpreference)
=> 구현완료

4. 홈화면 가운데에 이미지뷰 하나 추가해서 마이페이지에 있는 캐릭터 가져와서 띄워놓기
=>SPF참고하여서 url 로드하게 하였음