### PR TITLE
[Feat] 몬스터 배치 개선 및 완료 애니메이션 구현

### DIFF
--- a/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
@@ -36,7 +36,6 @@ class HomeFragment:Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         loadAllData()
-        Log.d("onViewCheck", "check")
         monsterAdapter = MonsterAdapter(
             items = emptyList(),
             onItemClick = { todo ->
@@ -46,10 +45,20 @@ class HomeFragment:Fragment() {
                 }.show(parentFragmentManager, "HomeDetailDialog")
             }
         )
-        binding.homeMonsterRv.layoutManager = LinearLayoutManager(requireContext()).apply {
-            stackFromEnd = true     // 아이템을 아래에서부터 쌓기
-            reverseLayout = false   // 데이터 순서는 그대로
-        }
+
+        // 1. 패턴 정의
+        val pattern = listOf(
+            0.65f to 0.9f,
+            0.35f to 0.75f,
+            0.85f to 0.6f,
+            0.2f to 0.45f,
+            0.55f to 0.3f
+        )
+        // 2. 아이템 크기(px) 계산
+        val itemPx = (100 * resources.displayMetrics.density).toInt() // 100dp → px 변환
+        // 3. 커스텀 LayoutManager 적용
+        binding.homeMonsterRv.layoutManager = MonsterPatternLayoutManager(pattern, itemPx, itemPx)
+        // 4. 어댑터 연결
         binding.homeMonsterRv.adapter = monsterAdapter
 
 

--- a/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/HomeFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.hideinbash.tododudu.databinding.FragmentHomeBinding
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +24,9 @@ class HomeFragment:Fragment() {
 
     private lateinit var monsterAdapter: MonsterAdapter
 
+    // 완료 예정인 할 일들을 추적하는 Set
+    private val completingTodos = mutableSetOf<Long>()
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -40,13 +42,26 @@ class HomeFragment:Fragment() {
             items = emptyList(),
             onItemClick = { todo ->
                 // 할 일 아이템 클릭 시 처리
-                HomeDetailDialogFragment.newInstance(todo) {
-                    loadAllData()
-                }.show(parentFragmentManager, "HomeDetailDialog")
+                HomeDetailDialogFragment.newInstance(
+                    todo = todo,
+                    onComplete = { todoId ->
+                        handleTodoCompletion(todoId)
+                    },
+                    onUpdate = { todoId ->
+                        // 수정 완료 시 데이터만 새로고침 (완료 처리 X)
+                        loadAllData()
+                    }
+                ).show(parentFragmentManager, "HomeDetailDialog")
             }
         )
 
-        // 1. 패턴 정의
+        setupRecyclerView()
+        setupAddButton()
+        loadAllData()
+    }
+
+    private fun setupRecyclerView() {
+        // 패턴 정의
         val pattern = listOf(
             0.65f to 0.9f,
             0.35f to 0.75f,
@@ -54,24 +69,19 @@ class HomeFragment:Fragment() {
             0.2f to 0.45f,
             0.55f to 0.3f
         )
-        // 2. 아이템 크기(px) 계산
-        val itemPx = (100 * resources.displayMetrics.density).toInt() // 100dp → px 변환
-        // 3. 커스텀 LayoutManager 적용
+        val itemPx = (100 * resources.displayMetrics.density).toInt()   // 아이템 크기 (px 계산)
         binding.homeMonsterRv.layoutManager = MonsterPatternLayoutManager(pattern, itemPx, itemPx)
-        // 4. 어댑터 연결
         binding.homeMonsterRv.adapter = monsterAdapter
+    }
 
-
-        // 할 일 추가 버튼
+    private fun setupAddButton() {
         binding.homeAddBtn.setOnClickListener {
             TodoAddDialogFragment(
                 mode = TodoAddDialogFragment.Mode.CREATE,
-                onComplete = { loadAllData() }, // DB 작업 후 UI 갱신
+                onComplete = { loadAllData() },
                 date = currentDate.format(dbDateFormatter)
             ).show(parentFragmentManager, "TodoAddDialog")
         }
-
-        loadAllData()
     }
 
     private fun loadAllData() {
@@ -88,7 +98,7 @@ class HomeFragment:Fragment() {
             val character = info_prefs.getString("character","https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif")
 
             // 2. 할 일 데이터 (RoomDB)
-            val db = TodoDatabase.getInstance(requireContext())
+            val db = TodoDatabase.getInstance(requireContext().applicationContext)
             val dateStr = currentDate.format(dbDateFormatter)
             val allTodos = db.todoDao().getTodosByDate(dateStr)
             val yetTodos = db.todoDao().getYetTodosByDate(dateStr)
@@ -114,6 +124,81 @@ class HomeFragment:Fragment() {
                     .into(binding.homeMainCharacterIv)
             }
         }
+    }
+
+    // 할 일 완료 처리 로직
+    private fun handleTodoCompletion(todoId: Long) {
+        // 1. 완료 예정 상태로 추가
+        completingTodos.add(todoId)
+
+        // 2. 즉시 이미지 변경
+        monsterAdapter.setItemCompleting(todoId)
+
+        // 3. 2초 후 실제 DB 업데이트
+        CoroutineScope(Dispatchers.IO).launch {
+            kotlinx.coroutines.delay(2000)
+
+            try {
+                val db = TodoDatabase.getInstance(requireContext().applicationContext)
+
+                // 현재 할 일 정보 가져오기
+                val currentTodo = db.todoDao().getTodoById(todoId)
+                if (currentTodo != null && !currentTodo.isCompleted) {
+                    // 완료 상태로 업데이트
+                    val updatedTodo = currentTodo.copy(isCompleted = true)
+                    db.todoDao().updateTodo(updatedTodo)
+
+                    Log.d("HomeFragment", "Todo $todoId completed successfully")
+
+                    // UI 업데이트 (메인 스레드에서)
+                    withContext(Dispatchers.Main) {
+                        addXp(20)
+                        completingTodos.remove(todoId)
+                        loadAllData() // 데이터 새로고침
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("HomeFragment", "Error completing todo $todoId: ${e.message}")
+                // 에러 발생 시 완료 예정 상태 해제
+                withContext(Dispatchers.Main) {
+                    completingTodos.remove(todoId)
+                    monsterAdapter.removeCompletingItem(todoId)
+                }
+            }
+        }
+    }
+
+    private fun addXp(amount: Int) {
+        val prefs = requireContext().getSharedPreferences("user_data", 0)
+        var xp = prefs.getInt("xp", 0)
+        var level = prefs.getInt("level", 1)
+        var xpForNext = 100 + (level - 1) * 20 // 레벨업에 필요한 XP 계산
+
+        xp += amount
+
+        // 레벨업
+        while (xp >= xpForNext) {
+            xp -= xpForNext
+            level++
+            xpForNext = 100 + (level - 1) * 20 // 다음 레벨업에 필요한 XP 계산
+        }
+
+        // 레벨다운
+        while (xp < 0 && level > 1) {
+            level--
+            xpForNext = 100 + (level - 1) * 20 // 이전 레벨업에 필요한 XP 계산
+            xp += xpForNext
+        }
+
+        // 최소값 보정
+        if (xp < 0) xp = 0
+        if (level < 1) level = 1
+
+        prefs.edit()
+            .putInt("xp", xp)
+            .putInt("level", level)
+            .putInt("next_level_xp", xpForNext)
+            .apply()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
@@ -12,6 +12,9 @@ class MonsterAdapter(
     private val onItemClick: (Todo) -> Unit
 ) : RecyclerView.Adapter<MonsterAdapter.MonsterViewHolder>() {
 
+    // 완료 예정 상태인 아이템들의 ID를 저장
+    private val completingItems = mutableSetOf<Long>()
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MonsterViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_monster, parent, false)
         return MonsterViewHolder(view)
@@ -20,22 +23,37 @@ class MonsterAdapter(
     override fun onBindViewHolder(holder: MonsterAdapter.MonsterViewHolder, position: Int) {
         val item = items[position]
 
-        // 아이템의 우선순위에 따라 몬스터 이미지 glide 사용해서 url 가져와서 설정
+        // 완료 예정 상태인지 확인
+        val isCompleting = completingItems.contains(item.id)
 
-        val gifUrl = when(item.priority) {
-            1 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
-            2 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
-            3 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
-            else -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif" // 기본 몬스터 이미지 URL
+        val gifUrl = if (isCompleting) {
+            // 완료 상태 이미지 (priority별로 구분)
+            when(item.priority) {
+                1 -> "https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif"
+                2 -> "https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif"
+                3 -> "https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif"
+                else -> "https://animatedoss.s3.amazonaws.com/fad01384-aeea-4539-946e-025387d43e81/video.gif"
+            }
+        } else {
+            // 일반 상태 이미지 (priority별로 구분)
+            when(item.priority) {
+                1 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+                2 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+                3 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+                else -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+            }
         }
+
         Glide.with(holder.itemView.context)
             .asGif()
             .load(gifUrl)
             .into(holder.monsterIv)
 
-        // 아이템 클릭 리스너 설정
+        // 아이템 클릭 리스너 설정 (완료 예정 상태가 아닐 때만)
         holder.monsterIv.setOnClickListener {
-            onItemClick(item)
+            if (!isCompleting) {
+                onItemClick(item)
+            }
         }
     }
 
@@ -48,5 +66,20 @@ class MonsterAdapter(
     fun updateList(newItems: List<Todo>) {
         items = newItems
         notifyDataSetChanged()
+    }
+
+    // 특정 아이템을 완료 예정 상태로 설정
+    fun setItemCompleting(todoId: Long) {
+        completingItems.add(todoId)
+        // 해당 아이템의 위치를 찾아서 업데이트
+        val position = items.indexOfFirst { it.id == todoId }
+        if (position != -1) {
+            notifyItemChanged(position)
+        }
+    }
+
+    // 완료 예정 상태 해제 (실제 완료 후 목록에서 제거될 때)
+    fun removeCompletingItem(todoId: Long) {
+        completingItems.remove(todoId)
     }
 }

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
@@ -28,11 +28,6 @@ class MonsterAdapter(
         }
         holder.monsterIv.setImageResource(monsterRes)
 
-        // 좌우 랜덤 위치 지정
-        val layoutParams = holder.monsterIv.layoutParams as ConstraintLayout.LayoutParams
-        layoutParams.horizontalBias = (0..100).random() / 100f
-        holder.monsterIv.layoutParams = layoutParams
-
         // 아이템 클릭 리스너 설정
         holder.monsterIv.setOnClickListener {
             onItemClick(item)

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
@@ -4,8 +4,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 
 class MonsterAdapter(
     private var items: List<Todo>,
@@ -20,13 +20,18 @@ class MonsterAdapter(
     override fun onBindViewHolder(holder: MonsterAdapter.MonsterViewHolder, position: Int) {
         val item = items[position]
 
-        val monsterRes = when(item.priority) {
-            1 -> R.drawable.monster_1
-            2 -> R.drawable.monster_2
-            3 -> R.drawable.monster_3
-            else -> R.drawable.monster_3 // 기본 몬스터 이미지
+        // 아이템의 우선순위에 따라 몬스터 이미지 glide 사용해서 url 가져와서 설정
+
+        val gifUrl = when(item.priority) {
+            1 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+            2 -> "https://animatedoss.s3.amazonaws.com/14563cf1-a95b-4110-a12c-4f0ee8f36fd8/video.gif"
+            3 -> "https://animatedoss.s3.amazonaws.com/da32ac1c-a684-49aa-9ef3-0a9ca1259612/video.gif"
+            else -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif" // 기본 몬스터 이미지 URL
         }
-        holder.monsterIv.setImageResource(monsterRes)
+        Glide.with(holder.itemView.context)
+            .asGif()
+            .load(gifUrl)
+            .into(holder.monsterIv)
 
         // 아이템 클릭 리스너 설정
         holder.monsterIv.setOnClickListener {

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterAdapter.kt
@@ -24,8 +24,8 @@ class MonsterAdapter(
 
         val gifUrl = when(item.priority) {
             1 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
-            2 -> "https://animatedoss.s3.amazonaws.com/14563cf1-a95b-4110-a12c-4f0ee8f36fd8/video.gif"
-            3 -> "https://animatedoss.s3.amazonaws.com/da32ac1c-a684-49aa-9ef3-0a9ca1259612/video.gif"
+            2 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
+            3 -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif"
             else -> "https://animatedoss.s3.amazonaws.com/59e26adf-ecd7-40e6-b319-1a5510dd42e6/video.gif" // 기본 몬스터 이미지 URL
         }
         Glide.with(holder.itemView.context)

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterPatternLayoutManager.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterPatternLayoutManager.kt
@@ -35,6 +35,12 @@ class MonsterPatternLayoutManager(
         val totalGroups = (itemCount + patternSize - 1) / patternSize
         val totalHeight = totalGroups * groupHeight
 
+        // 아래에서 시작하도록 verticalOffset을 최대값으로 설정
+        val maxOffset = (totalHeight - height).coerceAtLeast(0)
+        if (verticalOffset == 0) {
+            verticalOffset = maxOffset
+        }
+
         // 아래(리스트 끝)부터 아이템을 배치
         for (i in 0 until itemCount) {
             val reverseIndex = itemCount - 1 - i

--- a/app/src/main/java/com/hideinbash/tododudu/MonsterPatternLayoutManager.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/MonsterPatternLayoutManager.kt
@@ -1,0 +1,70 @@
+package com.hideinbash.tododudu
+
+import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * 몬스터를 자연스럽게 배치하는 커스텀 LayoutManager.
+ * - pattern: (x, y) 비율 패턴 리스트 (0~1 권장)
+ * - itemWidth, itemHeight: 각 아이템의 크기(px)
+ * - verticalSpacing: 패턴 그룹 간 세로 간격(px)
+ */
+class MonsterPatternLayoutManager(
+    private val pattern: List<Pair<Float, Float>>,
+    private val itemWidth: Int,
+    private val itemHeight: Int,
+    private val verticalSpacing: Int = 20
+) : RecyclerView.LayoutManager() {
+
+    private var verticalOffset = 0
+
+    override fun generateDefaultLayoutParams(): RecyclerView.LayoutParams =
+        RecyclerView.LayoutParams(itemWidth, itemHeight)
+
+    override fun canScrollVertically(): Boolean = true
+
+    override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
+        detachAndScrapAttachedViews(recycler)
+        if (itemCount == 0) return
+
+        val parentWidth = width
+        val patternSize = pattern.size
+        val groupHeight = height / 2 + verticalSpacing
+
+        // 전체 그룹(패턴 반복 묶음) 수와 전체 높이 계산
+        val totalGroups = (itemCount + patternSize - 1) / patternSize
+        val totalHeight = totalGroups * groupHeight
+
+        // 아래(리스트 끝)부터 아이템을 배치
+        for (i in 0 until itemCount) {
+            val reverseIndex = itemCount - 1 - i
+            val patternIndex = reverseIndex % patternSize
+            val groupIndex = reverseIndex / patternSize
+
+            val (xRatio, yRatio) = pattern[patternIndex]
+            val left = (parentWidth * xRatio).toInt() - itemWidth / 2
+            val top = totalHeight - groupHeight * (groupIndex + 1) + (groupHeight * yRatio).toInt() - verticalOffset - 200
+
+            val view = recycler.getViewForPosition(i)
+            addView(view)
+            measureChildWithMargins(view, 0, 0)
+            layoutDecorated(view, left, top, left + itemWidth, top + itemHeight)
+        }
+    }
+
+    override fun scrollVerticallyBy(dy: Int, recycler: RecyclerView.Recycler, state: RecyclerView.State): Int {
+        val parentHeight = height
+        val patternSize = pattern.size
+        val groupHeight = itemHeight * 2 + verticalSpacing
+        val totalGroups = (itemCount + patternSize - 1) / patternSize
+        val totalHeight = totalGroups * groupHeight
+
+        val maxOffset = totalHeight - parentHeight
+        val newOffset = (verticalOffset + dy).coerceIn(0, maxOffset.coerceAtLeast(0))
+        val delta = newOffset - verticalOffset
+        verticalOffset = newOffset
+        offsetChildrenVertical(-delta)
+        requestLayout()
+        return delta
+    }
+}

--- a/app/src/main/java/com/hideinbash/tododudu/TodoDao.kt
+++ b/app/src/main/java/com/hideinbash/tododudu/TodoDao.kt
@@ -22,4 +22,8 @@ interface TodoDao {
 
     @Query("SELECT * FROM todo WHERE date BETWEEN :startDate AND :endDate")
     suspend fun getTodosBetweenDates(startDate: String, endDate: String): List<Todo>
+
+    // id로 todo 찾기
+    @Query("SELECT * FROM todo WHERE id = :id")
+    suspend fun getTodoById(id: Long): Todo?
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -90,7 +90,7 @@
         app:layout_constraintTop_toBottomOf="@id/home_xp_pb"
         app:layout_constraintBottom_toTopOf="@id/home_main_character_iv"
         android:layout_marginTop="10dp"
-        android:layout_marginBottom="40dp"/>
+        android:layout_marginBottom="30dp"/>
 
     <ImageView
         android:id="@+id/home_add_btn"

--- a/app/src/main/res/layout/item_monster.xml
+++ b/app/src/main/res/layout/item_monster.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="3dp">
     
     <ImageView
         android:id="@+id/monster_iv"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
         android:src="@drawable/monster_1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_monster.xml
+++ b/app/src/main/res/layout/item_monster.xml
@@ -7,8 +7,8 @@
     
     <ImageView
         android:id="@+id/monster_iv"
-        android:layout_width="90dp"
-        android:layout_height="90dp"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
         android:src="@drawable/monster_1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
몬스터 배치 개선
- 커스텀 LayoutManager를 이용하여 5개마다 고정된 위치 패턴으로 반복되게 구현

할일 완료 애니메이션 구현
- 홈에서 특정 몬스터를 누른 후 다이얼로그에서 완료버튼을 누르면 몬스터 사라지는 애니메이션 표시 후 2초후 삭제
- 현재는 이미지 리소스 문제로 priority 구분 없이 다 동일한 gif로 되어있지만, 3가지 각각 다르게 교체해야함